### PR TITLE
Lightning AI BYOC compatibility changes

### DIFF
--- a/quick-start/main.tf
+++ b/quick-start/main.tf
@@ -7,9 +7,12 @@ terraform {
 }
 
 provider "aws" {
-
+  region = var.region
 }
 
 module "byoc" {
   source = "../."
+
+  role_name = var.role_name
+  grid_account_id = "748115360335"
 }

--- a/quick-start/variables.tf
+++ b/quick-start/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+    type = string 
+    description = "AWS region to deploy BYOC dependencies into"
+}
+
+variable "role_name" {
+    type = string 
+    description = "AWS role name to use"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,8 +7,8 @@ variable "external_id_override" {
 
 variable "grid_account_id" {
   type        = string
-  default     = "302180240179"
-  description = "Grid'a AWS account"
+  default     = "748115360335"
+  description = "Lightning AIs AWS account"
 }
 
 variable "extra_assume_role_arn" {


### PR DESCRIPTION
we can't default to 302180240179 for L.ai BYOC.
